### PR TITLE
add pyproject.toml file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+[project]
+name = "go_git"
+version = "0.1.0"
+description = "A repo of functions?."
+readme = "README.md"
+requires-python = ">=3.8"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+filterwarnings = [
+    "error",
+]
+
+[tool.ruff]
+src = ["src"]
+fix = true
+show-fixes = true
+output-format = "full"
+
+[tool.ruff.lint]
+select = [
+    "B",  # flake8-bugbear
+    "E",  # pycodestyle error
+    "F",  # pyflakes
+    "I",  # isort
+    "UP",  # pyupgrade
+    "W",  # pycodestyle warning
+]
+ignore-init-module-imports = true
+
+[tool.ruff.lint.isort]
+force-single-line = true
+order-by-type = false


### PR DESCRIPTION
Hi Bruno, this pull request is to add a `pyproject.toml` file, you can read more about it  [here](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/). 
As of right now it only has the options for the [`ruff` formatter/linter](https://github.com/astral-sh/ruff) and for `pytest`.
